### PR TITLE
Fixed errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # news-reader : Single Point News Reader
 
-This sample consists of a simple web page where the user can customize their news-reading experience, by selecting specific news channels.
+This sample consists of a web page where the user can customize their news-reading experience by selecting specific news channels.
 
 Note => This sample is designed as a Personal Project and is still in development stage.
 
 # Features
 
-* User can select what they want to from 70 trusted news sources like BBC, CNN, Bloomberg and etc
-* User can find top articles from multiple news channels at a single web-page
-* Provides a Headline and link to the actual website
+* Users can select their desired reading from 70 trusted news sources like BBC, CNN, Bloomberg, etc.
+* Users can find top articles from multiple news channels from a single web-page.
+* Provides a Headline and link to the actual website.
 
 # Limitations
 
-To read the full article, user gets redirected to the web-page of the news source
+To read the full article users gets redirected to the news source web-page.
 
 # Technology Stack
 


### PR DESCRIPTION
- Removed unnecessary words and punctuation from the first sentence.
- Under the "Features" section changed the sentence  "User can select what they want to from 70 trusted news sources like BBC, CNN, Bloomberg and etc" to "Users can select their desired reading from 70 trusted news sources like BBC, CNN, Bloomberg, etc." By replacing "what they want to" to "their desired readings", the sentence becomes more clear and less confusing.
- In the second sentence under "Features" changed "at" to "from" to remove a grammar mistake.
- In the "Limitations" section replaced "user gets redirected to the web-page of the news source" with "users gets redirected to the news source web-page" for concision purposes.